### PR TITLE
fix path to MASMx64 for Debug(x64) builds

### DIFF
--- a/contrib/vstudio/vc11/zlibvc.vcxproj
+++ b/contrib/vstudio/vc11/zlibvc.vcxproj
@@ -397,7 +397,7 @@ bld_ml32.bat</Command>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cd ..\..\contrib\masmx64
+      <Command>cd ..\..\masmx64
 bld_ml64.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/contrib/vstudio/vc12/zlibvc.vcxproj
+++ b/contrib/vstudio/vc12/zlibvc.vcxproj
@@ -342,7 +342,7 @@ bld_ml32.bat</Command>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cd ..\..\contrib\masmx64
+      <Command>cd ..\..\masmx64
 bld_ml64.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/contrib/vstudio/vc14/zlibvc.vcxproj
+++ b/contrib/vstudio/vc14/zlibvc.vcxproj
@@ -344,7 +344,7 @@ bld_ml32.bat</Command>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cd ..\..\contrib\masmx64
+      <Command>cd ..\..\masmx64
 bld_ml64.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/contrib/vstudio/vc15/zlibvc.vcxproj
+++ b/contrib/vstudio/vc15/zlibvc.vcxproj
@@ -344,7 +344,7 @@ bld_ml32.bat</Command>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cd ..\..\contrib\masmx64
+      <Command>cd ..\..\masmx64
 bld_ml64.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/contrib/vstudio/vc16/zlibvc.vcxproj
+++ b/contrib/vstudio/vc16/zlibvc.vcxproj
@@ -344,7 +344,7 @@ bld_ml32.bat</Command>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cd ..\..\contrib\masmx64
+      <Command>cd ..\..\masmx64
 bld_ml64.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/contrib/vstudio/vc17/zlibvc.vcxproj
+++ b/contrib/vstudio/vc17/zlibvc.vcxproj
@@ -344,7 +344,7 @@ bld_ml32.bat</Command>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cd ..\..\contrib\masmx64
+      <Command>cd ..\..\masmx64
 bld_ml64.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Correct a issue where Visual Studio 2022 (version 17.7) Debug|x64 fails to build due to an invalid relatove path.
Correction is also applied to other affected build systems