### PR TITLE
Add MSBuild Github Actions

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,20 @@
+name: MSBuild
+
+on: [push, pull_request]
+
+jobs:
+  Windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        architecture: [ Win32, x64, ARM64 ]
+      fail-fast: false
+    steps:
+    - name: Checkout zlib
+      uses: actions/checkout@v4
+      with:
+        path: zlib
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+    - name: Build
+      run: msbuild /t:zlibstat /p:Configuration=ReleaseWithoutAsm /p:Platform=${{ matrix.architecture }} ${{ github.workspace }}\zlib\contrib\vstudio\vc17\zlibvc.sln /verbosity:quiet /warnaserror


### PR DESCRIPTION
Only for `zlibstat` `ReleaseWithoutAsm`. The other MSVC project(s) does not build. Upstream seems to be moving towards CMake and VS projects may be abandoned.
